### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/GoogleMapsV2SkeletonV11/README.md
+++ b/GoogleMapsV2SkeletonV11/README.md
@@ -1,4 +1,4 @@
-#Skeleton Project
+# Skeleton Project
 
 This is a Google Maps Android API v2 Skeleton Project for API Level 11 and up.
 

--- a/GoogleMapsV2SkeletonV8/README.md
+++ b/GoogleMapsV2SkeletonV8/README.md
@@ -1,4 +1,4 @@
-#Skeleton Project
+# Skeleton Project
 
 This is a Google Maps Android API v2 Skeleton Project for API Level 8 and up.
 

--- a/GoogleMapsV2WithActionBarSherlock/README.md
+++ b/GoogleMapsV2WithActionBarSherlock/README.md
@@ -4,26 +4,26 @@ title: Index
 ---
 This sample application is part of a 3-part tutorial covering
 
-####[Part 1 : Setting up the Maps component with ActionBarSherlock](docs/part1.md)
+#### [Part 1 : Setting up the Maps component with ActionBarSherlock](docs/part1.md)
 - Setup a skeleton project
 - Add the ActionBarSherlock and GooglePlayServices libs
 	
-####[Part 2 : Drawing on the Map : Markers and polylines.](docs/part2.md)
+#### [Part 2 : Drawing on the Map : Markers and polylines.](docs/part2.md)
 - Adding markers
 - Highlighting markers
 - Removing markers
 	
-####[Part 3 : Animating the Map : Markers and polylines.](docs/part3.md)
+#### [Part 3 : Animating the Map : Markers and polylines.](docs/part3.md)
 - Animate through a set of markers on the map
 	
-####[Part 4 : Migrating from v1 maps to v2 maps.](docs/part4.md)
+#### [Part 4 : Migrating from v1 maps to v2 maps.](docs/part4.md)
 - Some tips and tricks for migrating your old v1 apps to v2.
 - A rundown of all the changes.
 
-####[Part 5 : Using the android-maps-utils.](docs/part5.md)
+#### [Part 5 : Using the android-maps-utils.](docs/part5.md)
 - Using the Android Map Utils library (to be completed).
 	
-####[Part 6 : Using Google APIs : Directions and Places API.](docs/part6.md)
+#### [Part 6 : Using Google APIs : Directions and Places API.](docs/part6.md)
 - Use Google Places Autocomplete API
 - Use Google Directions API
 - Putting everything together.

--- a/GoogleMapsV2WithActionBarSherlock/docs/part1.md
+++ b/GoogleMapsV2WithActionBarSherlock/docs/part1.md
@@ -3,9 +3,9 @@ layout: index
 title: Setting up the project
 ---
 
-##Part 1 : Setting up the project.
+## Part 1 : Setting up the project.
 
-###Introduction
+### Introduction
 
 In the first part of this tutorial I will show you can start using Google Maps Android API v2 in your Android application. 
 The goal is to create a skeleton project that 
@@ -14,7 +14,7 @@ The goal is to create a skeleton project that
 - uses ActionBarsherlock.
 - can run on older versions of Android (2.x and up).
  
-###Google Maps Android API v2
+### Google Maps Android API v2
  
 The new Google Maps Android API v2 ((available through Google Play Services)) is a vast improvement over the original one and comes with many new features. 
 Not only does it really stand out from a UI perspective but also on an API level is the new Maps v2 library a "delight" for both end-users and developers.

--- a/GoogleMapsV2WithActionBarSherlock/docs/part3.md
+++ b/GoogleMapsV2WithActionBarSherlock/docs/part3.md
@@ -3,7 +3,7 @@ layout: index
 title: Animating the map
 ---
 
-##Part 3 : Animating the map
+## Part 3 : Animating the map
 
 In the previous sections we've seen how to setup your map applications, how to move around the map with the camera, and how to add markers and lines to the map.
 In this last part we're going to create an animation that resembles a fly-over.
@@ -233,7 +233,7 @@ And finally start the animation again.
 	
 
 
-###References
+### References
 
 [1]: http://www.geomidpoint.com/destination/
 [2]: http://grepcode.com/file/repository.grepcode.com/java/ext/com.google.android/android/2.2_r1.1/android/location/Location.java#Location.computeDistanceAndBearing%28double%2Cdouble%2Cdouble%2Cdouble%2Cfloat%5B%5D%29

--- a/GoogleMapsV2WithActionBarSherlock/docs/part4.md
+++ b/GoogleMapsV2WithActionBarSherlock/docs/part4.md
@@ -185,7 +185,7 @@ but proper animation support is built into the API, allowing us to specify durat
 
 		
 		
-##References
+## References
 
 - [Google Maps Android API v2] (https://developers.google.com/maps/documentation/android/)
 - [Android Maps Extensions](https://github.com/mg6maciej/android-maps-extensions)

--- a/GoogleMapsV2WithActionBarSherlock/docs/part5.md
+++ b/GoogleMapsV2WithActionBarSherlock/docs/part5.md
@@ -20,7 +20,7 @@ See later on why.
 
 Next step is to import the code in our ADT.
 
-###Import the code in ADT.
+### Import the code in ADT.
 
 When importing code in ADT it's always best to import code from a location that's outside your standard eclipse workspace.
 Otherwise you might run into the following error 
@@ -44,7 +44,7 @@ Next up is to reference the android-maps-utils Library project on our project.
 [INSERT screenshot] 
 
 
-##References
+## References
 
 [0]: http://www.youtube.com/watch?feature=player_embedded&v=nb2X9IjjZpM#!
 [1]: https://github.com/googlemaps/android-maps-utils

--- a/GoogleMapsV2WithActionBarSherlock/docs/part6.md
+++ b/GoogleMapsV2WithActionBarSherlock/docs/part6.md
@@ -3,7 +3,7 @@ layout: index
 title: Document Center3
 ---
 
-##Using Google APIs on your map : Directions and Places
+## Using Google APIs on your map : Directions and Places
 
 In the following part I'll show you howto integrate with 2 popular Google APIs that you can use to enrich your Maps experience, the `Directions API` and the `Places API`.
 
@@ -14,17 +14,17 @@ After the user has entered an origin and a destination, we'll show the direction
 We're going to be using AsyncTask to perform the HTTP processing in the background off the main thread. 
 For the actual HTTP communication we're going to be using the [Google HTTP Client Library for Java][0].
 
-###The Google Directions API
+### The Google Directions API
 The Google Directions API is a service that calculates directions between locations using an HTTP request. We'll use it to draw a path (a polyline) between 2 points (origin and destination).
 
-###The Google Places API
+### The Google Places API
 The Google Places API is a service that returns information about Places — defined within this API as establishments, geographic locations, or prominent points of interest — using HTTP requests. Place requests specify locations as latitude/longitude coordinates.
 We're going to be using a small part of the Google Places API, namely the Places Autocomplete API.
 
-###Places Autocomplete
+### Places Autocomplete
 The Google Places Autocomplete API is a web service that returns Place information based on text search terms, and, optionally, geographic bounds. The API can be used to provide autocomplete functionality for text-based geographic searches, by returning Places such as businesses, addresses, and points of interest as a user types.
 
-###Directions input
+### Directions input
 
 We're going to use a GridLayout to build our directions input layout.
 We add a couple of labels and 2 AutoCompleteTextView components to the layout.
@@ -147,7 +147,7 @@ As the user is typing, he'll get the hints from the Google Places Autocompletion
 		
 The grunt of the work happens in the `autocomplete` method. I've used a different approach for that one as I wanted to use the [Google HTTP Client Library for Java][0] to connect to the Google API and parse the results, as opposed to using a lower-level `HttpURLConnection` to make the HTTP connection, and parsing the JSON response using a `JSONObject`.
 
-###Communicating the the Google Services
+### Communicating the the Google Services
   
 The [Google HTTP Client Library for Java][0] provides an easy and convenient way to interact with JSON based webservices like the ones we'll be discussing today
 
@@ -164,7 +164,7 @@ The JSON Factory is the low-level JSON library implementation based on Jackson 2
 
 We'll use the [Google HTTP Client Library for Java][0] for both the Places Autocompletion API call as well as for the Directions API call.
 
-###Places Autocompletion API
+### Places Autocompletion API
 
 Using our HttpTransport, we create an `HttpRequestFactory` (responsible for setting the parser) that we'll use to build our actual HTTP requests.
 
@@ -305,7 +305,7 @@ The complete code is pretty condensed and simple:
 		}	
 		
 
-###Directions API call
+### Directions API call
 
 The Directions API call use an AsyncTask to fetch the data in the background.	
 	
@@ -435,7 +435,7 @@ The full code can be found here.
 	}	
 
 
-###References
+### References
 
 - [Google HTTP Client Library for Java][0]
 - [The Google Directions API][1]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-##Introduction
+## Introduction
 
 This repository contains a number of projects that will help you get up to speed with Google Maps v2 on Android with ActionBarSherlock 4.3.1
 
@@ -12,35 +12,35 @@ It contains the following folders
 
 Note : This project was created for Eclipse ADT so on the master branch you can checkout the projects, import them in Eclipse and you should be good to go. For people working with Android Studio, I've created a [new branch](https://github.com/ddewaele/GoogleMapsV2WithActionBarSherlock/tree/androidstudio_migration) called ```androidstudio_migration1``` where you can checkout a Gradle enable version that you can import in Android Studio and get started immediately.
 
-##Tutorial
+## Tutorial
 
 The tutorial guides can be found in the docs folder of this project. The sample application is part of a 6-part tutorial covering
 
-###Part 1 : Setting up the Maps component with ActionBarSherlock
+### Part 1 : Setting up the Maps component with ActionBarSherlock
 
 - Setup a skeleton project
 - Add the ActionBarSherlock and GooglePlayServices libs
 - [More](./GoogleMapsV2WithActionBarSherlock/docs/part1.md)
 	
-###Part 2 : Drawing on the Map - Markers and polylines
+### Part 2 : Drawing on the Map - Markers and polylines
 
 - Adding markers
 - Highlighting markers
 - Removing markers
 - [More](./GoogleMapsV2WithActionBarSherlock/docs/part2.md)
 
-###Part 3 : Animating the Map
+### Part 3 : Animating the Map
 
 - Animate through a set of markers on the map
 - [More](./GoogleMapsV2WithActionBarSherlock/docs/part3.md)
 	
-###Part 4 : Migrating from v1 maps to v2 maps
+### Part 4 : Migrating from v1 maps to v2 maps
 
 - Some tips and tricks for migrating your old v1 apps to v2.
 - A rundown of all the changes.
 - [More](./GoogleMapsV2WithActionBarSherlock/docs/part4.md)
 
-###Part 5 : Using Google APIs : Directions and Places API
+### Part 5 : Using Google APIs : Directions and Places API
 
 - Use Google Places Autocomplete API
 - Use Google Directions API
@@ -51,7 +51,7 @@ The tutorial guides can be found in the docs folder of this project. The sample 
 **Important note:**
 
 
-###API keys
+### API keys
 In order to run this application on your phone you'll first need to get an API key.
 
 Instructions on how to setup your API key can be found in the [Setting up an Android Maps V2 Project][0] article.
@@ -62,7 +62,7 @@ You'll need to paste the API key into your application manifest on the following
 <meta-data android:name="com.google.android.maps.v2.API_KEY" android:value="INSERT_YOUR_API_KEY_HERE"/>
 ```
 
-###Library issues
+### Library issues
 If you attempt to run an Android sample app with your own copy of ActionBarSherlock, you might run into the following issue:
 
 	Found 2 versions of android-support-v4.jar in the dependency list,


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
